### PR TITLE
feat: Add Notarization and staple for macOS eim executables

### DIFF
--- a/.github/workflows/build_rust.yaml
+++ b/.github/workflows/build_rust.yaml
@@ -115,7 +115,7 @@ jobs:
             xcrun notarytool submit release/${{ matrix.os }}/eim.zip --keychain-profile "eim-notarytool-profile" --wait
           
             echo "Unzipping the executable"
-            unzip release/${{ matrix.os }}/eim.zip -d release/${{ matrix.os }}
+            unzip -o release/${{ matrix.os }}/eim.zip -d release/${{ matrix.os }}
          
             echo "Attach staple for eim executable"
             xcrun stapler staple release/${{ matrix.os }}/eim

--- a/.github/workflows/build_rust.yaml
+++ b/.github/workflows/build_rust.yaml
@@ -88,7 +88,7 @@ jobs:
           /usr/bin/security import certificate.p12 -k build.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
           /usr/bin/security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k espressif build.keychain
 
-          /usr/bin/codesign --options runtime --force -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" release/${{ matrix.os }}/eim -v
+          /usr/bin/codesign --entitlements eim.entitlement --options runtime --force -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" release/${{ matrix.os }}/eim -v
           /usr/bin/codesign -v -vvv --deep release/${{ matrix.os }}/eim
     
       - name: Zip eim executable for notarization

--- a/.github/workflows/build_rust.yaml
+++ b/.github/workflows/build_rust.yaml
@@ -75,7 +75,7 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: cp target/release/idf-im-cli release/${{ matrix.os }}/eim
       
-      - name: Codesign macOS build artifacts
+      - name: Codesign macOS eim executables
         if: startsWith(matrix.os, 'macos')
         env: 
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
@@ -90,7 +90,30 @@ jobs:
 
           /usr/bin/codesign --options runtime --force -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" release/${{ matrix.os }}/eim -v
           /usr/bin/codesign -v -vvv --deep release/${{ matrix.os }}/eim
-
+      
+      - name: Notarization of macOS eim executables
+        # && github.ref == 'refs/heads/master'
+        if: startsWith(matrix.os, 'macos') 
+        env: 
+          NOTARIZATION_USERNAME: ${{ secrets.NOTARIZATION_USERNAME }}
+          NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
+          NOTARIZATION_TEAM_ID: ${{ secrets.NOTARIZATION_TEAM_ID }}
+        run: |
+            echo "Create notary keychain"
+            /usr/bin/security create-keychain -p espressif notary.keychain
+            /usr/bin/security default-keychain -s notary.keychain
+            /usr/bin/security unlock-keychain -p espressif notary.keychain
+      
+            echo "Create keychain profile"
+            xcrun notarytool store-credentials "eim-notarytool-profile" --apple-id $NOTARIZATION_USERNAME --team-id $NOTARIZATION_TEAM_ID --password $NOTARIZATION_PASSWORD
+            xcrun notarytool submit release/${{ matrix.os }}/eim --keychain-profile "eim-notarytool-profile" --wait
+              
+            echo "Attach staple for eim executable"
+            xcrun stapler staple release/${{ matrix.os }}/eim
+              
+            echo "Unlock the notary keychain"
+            /usr/bin/security unlock-keychain -p espressif notary.keychain
+            
       - name: Upload build artifacts for POSIX
         uses: actions/upload-artifact@v4
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/build_rust.yaml
+++ b/.github/workflows/build_rust.yaml
@@ -113,19 +113,22 @@ jobs:
             echo "Create keychain profile"
             xcrun notarytool store-credentials "eim-notarytool-profile" --apple-id $NOTARIZATION_USERNAME --team-id $NOTARIZATION_TEAM_ID --password $NOTARIZATION_PASSWORD
             xcrun notarytool submit release/${{ matrix.os }}/eim.zip --keychain-profile "eim-notarytool-profile" --wait
-              
+          
+            echo "Unzipping the executable"
+            unzip release/${{ matrix.os }}/eim.zip -d release/${{ matrix.os }}
+         
             echo "Attach staple for eim executable"
-            xcrun stapler staple release/${{ matrix.os }}/eim.zip
+            xcrun stapler staple release/${{ matrix.os }}/eim
               
-            echo "Unlock the notary keychain"
-            /usr/bin/security unlock-keychain -p espressif notary.keychain
+            echo "Verifying the stapling"
+            xcrun stapler validate release/${{ matrix.os }}/eim
     
       - name: Upload build artifacts for POSIX
         uses: actions/upload-artifact@v4
         if: matrix.os != 'windows-latest'
         with:
           name: eim-${{ matrix.os }}
-          path: release/${{ matrix.os }}/eim.zip
+          path: release/${{ matrix.os }}/eim
 
       - name: Upload artifact for tag on POSIX
         if: startsWith(github.ref, 'refs/tags/') && matrix.os != 'windows-latest'

--- a/.github/workflows/build_rust.yaml
+++ b/.github/workflows/build_rust.yaml
@@ -90,7 +90,13 @@ jobs:
 
           /usr/bin/codesign --options runtime --force -s "ESPRESSIF SYSTEMS (SHANGHAI) CO., LTD. (QWXF6GB4AV)" release/${{ matrix.os }}/eim -v
           /usr/bin/codesign -v -vvv --deep release/${{ matrix.os }}/eim
-      
+    
+      - name: Zip eim executable for notarization
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          cd release/${{ matrix.os }}
+          zip eim.zip eim      
+          
       - name: Notarization of macOS eim executables
         # && github.ref == 'refs/heads/master'
         if: startsWith(matrix.os, 'macos') 
@@ -106,20 +112,20 @@ jobs:
       
             echo "Create keychain profile"
             xcrun notarytool store-credentials "eim-notarytool-profile" --apple-id $NOTARIZATION_USERNAME --team-id $NOTARIZATION_TEAM_ID --password $NOTARIZATION_PASSWORD
-            xcrun notarytool submit release/${{ matrix.os }}/eim --keychain-profile "eim-notarytool-profile" --wait
+            xcrun notarytool submit release/${{ matrix.os }}/eim.zip --keychain-profile "eim-notarytool-profile" --wait
               
             echo "Attach staple for eim executable"
-            xcrun stapler staple release/${{ matrix.os }}/eim
+            xcrun stapler staple release/${{ matrix.os }}/eim.zip
               
             echo "Unlock the notary keychain"
             /usr/bin/security unlock-keychain -p espressif notary.keychain
-            
+    
       - name: Upload build artifacts for POSIX
         uses: actions/upload-artifact@v4
         if: matrix.os != 'windows-latest'
         with:
           name: eim-${{ matrix.os }}
-          path: release/${{ matrix.os }}/eim
+          path: release/${{ matrix.os }}/eim.zip
 
       - name: Upload artifact for tag on POSIX
         if: startsWith(github.ref, 'refs/tags/') && matrix.os != 'windows-latest'

--- a/.github/workflows/build_rust.yaml
+++ b/.github/workflows/build_rust.yaml
@@ -117,8 +117,8 @@ jobs:
             echo "Unzipping the executable"
             unzip -o release/${{ matrix.os }}/eim.zip -d release/${{ matrix.os }}
          
-            echo "Attach staple for eim executable"
-            xcrun stapler staple release/${{ matrix.os }}/eim
+            # echo "Attach staple for eim executable"
+            # xcrun stapler staple release/${{ matrix.os }}/eim
               
       - name: Upload build artifacts for POSIX
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_rust.yaml
+++ b/.github/workflows/build_rust.yaml
@@ -120,9 +120,6 @@ jobs:
             echo "Attach staple for eim executable"
             xcrun stapler staple release/${{ matrix.os }}/eim
               
-            echo "Verifying the stapling"
-            xcrun stapler validate release/${{ matrix.os }}/eim
-    
       - name: Upload build artifacts for POSIX
         uses: actions/upload-artifact@v4
         if: matrix.os != 'windows-latest'

--- a/eim.entitlement
+++ b/eim.entitlement
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.debugger</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
- Added notorization for eim macos executables
- skipping staple for single executable file as per this https://forums.developer.apple.com/forums/thread/736973 as the server is not accepting.

```
Attach staple for eim executable
Processing: /Users/runner/work/idf-im-cli/idf-im-cli/release/macos-latest/eim
The staple and validate action failed! Error 73.
```