### PR TITLE
lock python version for windows install on 3.11.5

### DIFF
--- a/src/wizard/mod.rs
+++ b/src/wizard/mod.rs
@@ -642,7 +642,7 @@ pub async fn run_wizzard_run(mut config: Settings) -> Result<(), String> {
         version_instalation_path.push(&idf_version);
         let mut idf_path = version_instalation_path.clone();
         idf_path.push("esp-idf");
-        config.idf_path = Some(idf_path.clone());
+        config.idf_path = Some(idf_path.clone()); // todo: list all of the paths
         idf_im_lib::add_path_to_path(idf_path.to_str().unwrap());
 
         // download idf

--- a/src/wizard/prompts.rs
+++ b/src/wizard/prompts.rs
@@ -106,7 +106,7 @@ pub fn check_and_install_python() -> Result<(), String> {
         if std::env::consts::OS == "windows" {
             info!("{}", t!("python.sanitycheck.fail"));
             if generic_confirm("pythhon.install.prompt").map_err(|e| e.to_string())? {
-                system_dependencies::install_prerequisites(vec!["python".to_string()])
+                system_dependencies::install_prerequisites(vec!["python@3.11.5".to_string()])
                     .map_err(|e| e.to_string())?;
                 let scp = system_dependencies::get_scoop_path();
                 let usable_python = match scp {


### PR DESCRIPTION
quick&dirty fix for the problem, the proper solution is to abandon pip and python altogether for installing python packages