### PR TITLE
WIP: version management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 /docs/_build/
 node_modules/
+**/.DS_Store
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "ar"
@@ -1050,11 +1050,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -1651,13 +1671,14 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 name = "idf-im-cli"
 version = "0.1.5"
 dependencies = [
+ "anyhow",
  "byte-unit",
  "clap",
  "config",
  "console",
  "crossterm 0.27.0",
  "dialoguer",
- "dirs",
+ "dirs 5.0.1",
  "git2",
  "idf-im-lib",
  "indicatif",
@@ -1677,16 +1698,17 @@ dependencies = [
 [[package]]
 name = "idf-im-lib"
 version = "0.1.8"
-source = "git+https://github.com/espressif/idf-im-lib.git?tag=v0.1.8#395f0f8c72c442054686a08e5d1602c222e6e1f5"
 dependencies = [
+ "anyhow",
  "colored",
  "config",
  "decompress",
- "dirs",
+ "dirs 5.0.1",
  "git2",
  "log",
  "regex",
  "reqwest",
+ "rust_search",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2234,6 +2256,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
 ]
 
 [[package]]
@@ -3072,6 +3104,19 @@ dependencies = [
  "rkyv",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "rust_search"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27d7be20245d289c9dde663f06521de08663d73cbaefc45785aa65d02022378"
+dependencies = [
+ "dirs 4.0.0",
+ "ignore",
+ "num_cpus",
+ "regex",
+ "strsim 0.10.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 tokio = {version = "1.37.0", features=["full"]}
-idf-im-lib = { git = "https://github.com/espressif/idf-im-lib.git", tag="v0.1.8" } 
+idf-im-lib = { path = "../idf-im-lib" } 
 clap = {version = "4.5", features = ["cargo", "derive", "color"]}
 crossterm = "0.27.0"
 dialoguer = { git = "https://github.com/Hahihula/dialoguer.git", branch = "folder-select", features = ["folder-select"] }
@@ -24,6 +24,7 @@ rust-i18n = "3.0.1"
 dirs = "5.0.1"
 toml = "0.8.14"
 log4rs = "1.3.0"
+anyhow = "1.0.93"
 
 [dependencies.openssl-sys]
 version = "0.9"

--- a/src/cli_args/mod.rs
+++ b/src/cli_args/mod.rs
@@ -1,6 +1,8 @@
 use clap::builder::styling::{AnsiColor, Color, Style, Styles};
-use clap::{arg, command, ColorChoice, Parser};
+use clap::{arg, command, ColorChoice, Parser, Subcommand};
 use std::path::PathBuf;
+
+// use clap::builder::styling::{AnsiColor, Color, Style, Styles};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -31,6 +33,53 @@ fn custom_styles() -> Styles {
     styles = custom_styles()
 )]
 pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+
+    #[arg(short, long, help = "Set the language for the wizard (en, cn)")]
+    pub locale: Option<String>,
+
+    #[arg(
+        short,
+        long,
+        action = clap::ArgAction::Count,
+        help = "Increase verbosity level (can be used multiple times)"
+    )]
+    pub verbose: u8,
+
+    #[arg(long, help = "file in which logs will be stored (default: eim.log)")]
+    pub log_file: Option<String>,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Install ESP-IDF versions and tools
+    Install(InstallArgs),
+
+    /// List installed ESP-IDF versions and tools
+    List,
+
+    /// Select an ESP-IDF version as active
+    Select {
+        #[arg(help = "Version to select as active")]
+        version: String,
+    },
+
+    /// Discover available ESP-IDF versions
+    Discover,
+
+    /// Remove specific ESP-IDF version
+    Remove {
+        #[arg(help = "Version to remove")]
+        version: String,
+    },
+
+    /// Purge all ESP-IDF installations
+    Purge,
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct InstallArgs {
     #[arg(
         short,
         long,
@@ -98,20 +147,6 @@ pub struct Cli {
     #[arg(
         short,
         long,
-        action = clap::ArgAction::Count,
-        help = "Increase verbosity level (can be used multiple times)"
-    )]
-    pub verbose: u8,
-
-    #[arg(short, long, help = "Set the language for the wizard (en, cn)")]
-    pub locale: Option<String>,
-
-    #[arg(long, help = "file in which logs will be stored (default: eim.log)")]
-    pub log_file: Option<String>,
-
-    #[arg(
-        short,
-        long,
         help = "Should the installer recurse into submodules of the ESP-IDF repository (default true) "
     )]
     pub recurse_submodules: Option<bool>,
@@ -130,7 +165,7 @@ pub struct Cli {
     pub config_file_save_path: Option<String>,
 }
 
-impl IntoIterator for Cli {
+impl IntoIterator for InstallArgs {
     type Item = (String, Option<config::Value>);
     type IntoIter = std::vec::IntoIter<Self::Item>;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use clap::Parser;
+use cli_args::{Cli, Commands};
 use config::ConfigError;
 use log::{debug, error, info, LevelFilter};
 extern crate idf_im_lib;
@@ -87,29 +88,68 @@ fn set_locale(locale: &Option<String>) {
 
 #[tokio::main]
 async fn main() {
-    let cli = cli_args::Cli::parse();
+    let cli = Cli::parse();
 
     setup_logging(&cli).unwrap();
     set_locale(&cli.locale);
 
-    let settings = Settings::new(cli.config.clone(), cli.into_iter());
-    // let settings = cli_args::Settings::new();
-    match settings {
-        Ok(settings) => {
-            let result = wizard::run_wizzard_run(settings).await;
-            match result {
-                Ok(r) => {
-                    info!("Wizard result: {:?}", r);
-                    println!("Successfully installed IDF");
-                    println!("Now you can start using IDF tools");
+    match &cli.command {
+        Commands::Install(install_args) => {
+            let settings = Settings::new(
+                install_args.config.clone(),
+                install_args.clone().into_iter(),
+            );
+            match settings {
+                Ok(settings) => {
+                    let result = wizard::run_wizzard_run(settings).await;
+                    match result {
+                        Ok(r) => {
+                            info!("Wizard result: {:?}", r);
+                            println!("Successfully installed IDF");
+                            println!("Now you can start using IDF tools");
+                        }
+                        Err(err) => error!("Error: {}", err),
+                    }
                 }
                 Err(err) => error!("Error: {}", err),
             }
         }
-        Err(err) => error!("Error: {}", err),
+        Commands::List => {
+            // Implement listing installed versions
+            println!("Listing installed versions...");
+        }
+        Commands::Select { version } => {
+            // Implement version selection
+            println!("Selecting version: {}", version);
+        }
+        Commands::Discover => {
+            // Implement version discovery
+            println!("Discovering available versions...");
+        }
+        Commands::Remove { version } => {
+            // Implement version removal
+            println!("Removing version: {}", version);
+        }
+        Commands::Purge => {
+            // Implement complete purge
+            println!("Purging all installations...");
+        }
     }
 
-    // next step is source the env vars
-    // activate venvironment
-    // or at least spit user instruction how to do this
+    // let settings = Settings::new(cli.config.clone(), cli.into_iter());
+    // // let settings = cli_args::Settings::new();
+    // match settings {
+    //     Ok(settings) => {
+    //         let result = wizard::run_wizzard_run(settings).await;
+    //         match result {
+    //             Ok(r) => {
+    //                 info!("Wizard result: {:?}", r);
+    //                 println!("Successfully installed IDF");
+    //                 println!("Now you can start using IDF tools");
+    //             }
+    //             Err(err) => error!("Error: {}", err),
+    //         }
+    //     }
+    //     Err(err) => error!("Error: {}", err),
+    // }
 }

--- a/src/wizard/mod.rs
+++ b/src/wizard/mod.rs
@@ -1,3 +1,5 @@
+use anyhow::anyhow;
+use anyhow::Result;
 use dialoguer::FolderSelect;
 use idf_im_lib::idf_tools::ToolsFile;
 use idf_im_lib::settings::Settings;
@@ -582,7 +584,13 @@ pub async fn run_wizzard_run(mut config: Settings) -> Result<(), String> {
         }
     }
     let ide_conf_path = ide_conf_path_tmp.join("esp_ide.json");
-    config.save_esp_ide_json(ide_conf_path.to_str().unwrap())?;
+    match config.save_esp_ide_json(ide_conf_path.to_str().unwrap()) {
+        Ok(_) => debug!("IDE configuration saved to: {}", ide_conf_path.display()),
+        Err(err) => {
+            error!("Failed to save IDE configuration: {}", err);
+            return Err(err.to_string());
+        }
+    };
 
     match std::env::consts::OS {
         "windows" => {


### PR DESCRIPTION
We are moving towards the management of the installations:
new CLI looks like
```

Usage: eim [OPTIONS] <COMMAND>

Commands:
  install   Install ESP-IDF versions and tools
  list      List installed ESP-IDF versions and tools
  select    Select an ESP-IDF version as active
  discover  Discover available ESP-IDF versions
  remove    Remove specific ESP-IDF version
  purge     Purge all ESP-IDF installations
  help      Print this message or the help of the given subcommand(s)

Options:
  -l, --locale <LOCALE>
          Set the language for the wizard (en, cn)

  -v, --verbose...
          Increase verbosity level (can be used multiple times)

      --log-file <LOG_FILE>
          file in which logs will be stored (default: eim.log)

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version

```
where the current CLI is hidden under the `install` command 