### PR TITLE
made the saving instalation config default behaviour

### DIFF
--- a/src/wizard/helpers.rs
+++ b/src/wizard/helpers.rs
@@ -46,9 +46,16 @@ pub fn generic_select(prompt_key: &str, options: &[&str]) -> Result<String, Stri
 }
 
 pub fn generic_confirm(prompt_key: &str) -> Result<bool, dialoguer::Error> {
+    generic_confirm_with_default(prompt_key, false)
+}
+
+pub fn generic_confirm_with_default(
+    prompt_key: &str,
+    default: bool,
+) -> Result<bool, dialoguer::Error> {
     Confirm::with_theme(&create_theme())
         .with_prompt(t!(prompt_key))
-        .default(false)
+        .default(default)
         .interact()
 }
 

--- a/src/wizard/prompts.rs
+++ b/src/wizard/prompts.rs
@@ -9,6 +9,8 @@ use idf_im_lib::system_dependencies;
 use log::{debug, info};
 use rust_i18n::t;
 
+use self::helpers::generic_confirm_with_default;
+
 pub async fn select_target() -> Result<Vec<String>, String> {
     let mut available_targets = idf_im_lib::idf_versions::get_avalible_targets().await?;
     available_targets.insert(0, "all".to_string());
@@ -232,7 +234,7 @@ pub fn save_config_if_desired(config: &Settings) -> Result<(), String> {
             debug!("Skipping config save in non-interactive mode.");
             Ok(false)
         } else {
-            generic_confirm("wizard.after_install.save_config.prompt")
+            generic_confirm_with_default("wizard.after_install.save_config.prompt", true)
         };
     if let Ok(true) = res {
         config


### PR DESCRIPTION
This PR changes the default value of the user prompt asking him if he wants to save the installation configuration.  The installation configuration is only useful if you want to reproduce the same installation multiple times.
Requested here: https://github.com/espressif/idf-im-cli/pull/74#issuecomment-2513688496